### PR TITLE
feat: Chat API 기능 구현 및 비동기 처리 적용 (#4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# 빌드 결과물 제외(libs/*jar 은 제외)
+build/
+!build/libs/*.jar
+**/.gradle
+
+# IDE 관련 파일
+*.iml
+.idea/
+.vscode/
+
+# Git 이력
+.git
+.gitignore
+
+README.md
+*.log
+.env
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ src/main/resources/application.yml
 application.yml
 application-local.yml
 application-dev.yml
+application-test.yml
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17-jdk
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/aivle/agriculture/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/controller/ChatController.java
@@ -1,0 +1,28 @@
+package com.aivle.agriculture.domain.chat.controller;
+
+import com.aivle.agriculture.domain.chat.dto.ChatRequest;
+import com.aivle.agriculture.domain.chat.dto.ChatResponse;
+import com.aivle.agriculture.domain.chat.service.ChatService;
+import com.aivle.agriculture.global.response.Response;
+import com.aivle.agriculture.global.response.ResponseFactory;
+import com.aivle.agriculture.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ResponseFactory responseFactory;
+    private final ChatService chatService;
+
+    @PostMapping
+    public Mono<Response<ChatResponse>> ask(@RequestBody ChatRequest request) {
+        return responseFactory.successMono(SuccessCode.OK, chatService.ask(request));
+    }
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatRequest.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatRequest.java
@@ -1,0 +1,4 @@
+package com.aivle.agriculture.domain.chat.dto;
+
+public record ChatRequest(String question) {
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatResponse.java
@@ -1,0 +1,7 @@
+package com.aivle.agriculture.domain.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatResponse(String answer) {
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/service/ChatService.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/service/ChatService.java
@@ -1,0 +1,9 @@
+package com.aivle.agriculture.domain.chat.service;
+
+import com.aivle.agriculture.domain.chat.dto.ChatRequest;
+import com.aivle.agriculture.domain.chat.dto.ChatResponse;
+import reactor.core.publisher.Mono;
+
+public interface ChatService {
+    Mono<ChatResponse> ask(ChatRequest request);
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/service/ChatServiceImpl.java
@@ -1,0 +1,31 @@
+package com.aivle.agriculture.domain.chat.service;
+
+import com.aivle.agriculture.domain.chat.dto.ChatRequest;
+import com.aivle.agriculture.domain.chat.dto.ChatResponse;
+import com.aivle.agriculture.domain.common.client.FastApiClient;
+import com.aivle.agriculture.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import static com.aivle.agriculture.global.response.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final FastApiClient fastApiClient;
+
+    @Override
+    public Mono<ChatResponse> ask(ChatRequest request) {
+        return fastApiClient.askRag(request.question())
+                .onErrorMap(error -> {
+//                    if (error instanceof SomeSpecificException) {
+//                        return new CustomException(ErrorCode.INVALID_INPUT);
+//                    }
+                    return new CustomException(INTERNAL_SERVER_ERROR, error);
+                });
+    }
+}

--- a/src/main/java/com/aivle/agriculture/domain/common/client/FastApiClient.java
+++ b/src/main/java/com/aivle/agriculture/domain/common/client/FastApiClient.java
@@ -1,0 +1,30 @@
+package com.aivle.agriculture.domain.common.client;
+
+import com.aivle.agriculture.domain.chat.dto.ChatResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Component
+public class FastApiClient {
+    private final WebClient webClient;
+
+    public FastApiClient(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public Mono<ChatResponse> askRag(String question) {
+        return webClient.post()
+                .uri("/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("question", question))
+                .retrieve()
+                .bodyToMono(ChatResponse.class);
+    }
+}
+
+

--- a/src/main/java/com/aivle/agriculture/global/config/WebClientConfig.java
+++ b/src/main/java/com/aivle/agriculture/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.aivle.agriculture.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient(WebClient.Builder builder, @Value("${external.fastapi-url}") String baseUrl) {
+        return builder.baseUrl(baseUrl).build();
+    }
+}

--- a/src/main/java/com/aivle/agriculture/global/exception/CustomException.java
+++ b/src/main/java/com/aivle/agriculture/global/exception/CustomException.java
@@ -16,4 +16,9 @@ public class CustomException extends RuntimeException {
         super(customMessage);
         this.errorCode = errorCode;
     }
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause); // 실제 예외
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/aivle/agriculture/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aivle/agriculture/global/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleException(Exception e) {
-        log.error("서버 예외 발생 : {}", e.getMessage());
+        log.error("서버 예외 발생 : {}", e.toString());
         return responseFactory.error(new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage()));
     }
 

--- a/src/main/java/com/aivle/agriculture/global/response/ResponseFactory.java
+++ b/src/main/java/com/aivle/agriculture/global/response/ResponseFactory.java
@@ -3,6 +3,7 @@ package com.aivle.agriculture.global.response;
 import com.aivle.agriculture.global.exception.CustomException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 @Component
 public class ResponseFactory {
@@ -28,5 +29,17 @@ public class ResponseFactory {
     public <T> ResponseEntity<Response<T>> error(CustomException e, T result) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(Response.of(e.getErrorCode(), result));
+    }
+
+    public <T> Mono<Response<T>> successMono(SuccessCode code, T result) {
+        return Mono.just(Response.of(code, result));
+    }
+
+    public <T> Mono<Response<T>> successMono(SuccessCode code, Mono<T> mono) {
+        return mono.map(data -> Response.of(code, data));
+    }
+
+    public Mono<Response<Void>> errorMono(CustomException e) {
+        return Mono.just(Response.of(e.getErrorCode(), null));
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
- /api/chat API 개발
- 비동기 처리를 위해 WebClient 사용
- ResponseFactory에 비동기 응답 형식 추가
- FastAPI 서버와의 통신 기능 구현
- 예외 관련 코드 변경

## 🌠  작업 결과
- Spring에서 FastAPI와 비동기 통신 성공
- 정상적으로 응답 데이터 매핑 및 반환 확인
- 예외 메시지 뿐만 아니라 실제 예외 자체 추적 가능

## ‼ 이슈 사항
현재는 MVC로 간단하게 만들어 놓음 -> 밑의 내용들로 고도화 해야함.
- 사용자 인증 추가 (JWT 기반) -> 현재는 그냥 요청-응답 통신으로만 간단하게 만들어져있음
- 대화 히스토리 저장 -> 대화 저장안하고있음 지금(사용자 인증 기능이 추가 되어야 할 수 있음) + Redis로 캐싱 예정
- (선택) 비동기 스트리밍 응답