### PR TITLE
feat: Nginx 설정 파일 추가 및 기본 라우팅 구성

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,38 @@
+upstream spring {
+    server spring-app:8080;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    location = /healthcheck {
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+
+    location / {
+        limit_req zone=one burst=5 nodelay;
+        limit_conn addr 10;
+
+        proxy_pass http://spring;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
+            add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin, X-Requested-With';
+            add_header 'Access-Control-Max-Age' 3600;
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            return 204;
+        }
+
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin, X-Requested-With';
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # 요청 속도 제한: IP당 초당 10건
+    limit_req_zone $binary_remote_addr zone=one:10m rate=10r/s;
+
+    # 동시 연결 제한: IP당 10개
+    limit_conn_zone $binary_remote_addr zone=addr:10m;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
- 80 포트로 요청을 받도록 Nginx 설정
- proxy cache 구성을 위한 기본 구조 마련
- default.conf 및 nginx.conf 파일 작성

## 📋 작업 내용
- 80 포트로 요청을 수신하도록 Nginx 설정
- 추후 proxy cache 기능을 위한 구조 구성
- default.conf, nginx.conf 설정 파일 작성 및 적용

## 🌠  작업 결과
- Spring 및 FastAPI 서비스에 대한 기본 라우팅 확인
- Docker 환경에서 Nginx 정상 작동 확인

Closes #7