### PR TITLE
Feature/conversational context

### DIFF
--- a/src/main/java/com/aivle/agriculture/domain/Login/entity/User.java
+++ b/src/main/java/com/aivle/agriculture/domain/Login/entity/User.java
@@ -2,13 +2,14 @@ package com.aivle.agriculture.domain.Login.entity;
 
 import com.aivle.agriculture.global.base.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
 public class User extends BaseEntity {
 

--- a/src/main/java/com/aivle/agriculture/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/controller/ChatController.java
@@ -7,11 +7,14 @@ import com.aivle.agriculture.global.response.Response;
 import com.aivle.agriculture.global.response.ResponseFactory;
 import com.aivle.agriculture.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/chat")
@@ -22,7 +25,12 @@ public class ChatController {
     private final ChatService chatService;
 
     @PostMapping
-    public Mono<Response<ChatResponse>> ask(@RequestBody ChatRequest request) {
-        return responseFactory.successMono(SuccessCode.OK, chatService.ask(request));
+    public ResponseEntity<Response<ChatResponse>> ask(@RequestBody ChatRequest request) {
+
+        String convId = Optional.ofNullable(request.conversationId())
+                .filter(id -> !id.isBlank())
+                .orElse(UUID.randomUUID().toString());
+
+        return responseFactory.success(SuccessCode.OK, chatService.ask(convId, request.question()));
     }
 }

--- a/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatRequest.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/dto/ChatRequest.java
@@ -1,4 +1,6 @@
 package com.aivle.agriculture.domain.chat.dto;
 
-public record ChatRequest(String question) {
+import jakarta.annotation.Nullable;
+
+public record ChatRequest(@Nullable String conversationId, String question) {
 }

--- a/src/main/java/com/aivle/agriculture/domain/chat/dto/RagPayload.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/dto/RagPayload.java
@@ -3,5 +3,5 @@ package com.aivle.agriculture.domain.chat.dto;
 import lombok.Builder;
 
 @Builder
-public record ChatResponse(String conversationId, String answer) {
+public record RagPayload(String conversationId, String context, String question) {
 }

--- a/src/main/java/com/aivle/agriculture/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,40 @@
+package com.aivle.agriculture.domain.chat.entity;
+
+import com.aivle.agriculture.domain.Login.entity.User;
+import com.aivle.agriculture.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "idx_conv_id", columnList = "conversationId"))
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String conversationId;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public ChatMessage(String conversationId, Role role, String content, User user) {
+        this.conversationId = conversationId;
+        this.role = role;
+        this.content = content;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/entity/Role.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/entity/Role.java
@@ -1,0 +1,5 @@
+package com.aivle.agriculture.domain.chat.entity;
+
+public enum Role {
+    USER, ASSISTANT;
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,14 @@
+package com.aivle.agriculture.domain.chat.repository;
+
+import com.aivle.agriculture.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    @Query("SELECT m FROM ChatMessage m WHERE m.conversationId = :convId ORDER BY m.createdAt DESC")
+    List<ChatMessage> findRecentMessages(String convId, Pageable pageable);
+}

--- a/src/main/java/com/aivle/agriculture/domain/chat/service/ChatService.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/service/ChatService.java
@@ -1,9 +1,7 @@
 package com.aivle.agriculture.domain.chat.service;
 
-import com.aivle.agriculture.domain.chat.dto.ChatRequest;
 import com.aivle.agriculture.domain.chat.dto.ChatResponse;
-import reactor.core.publisher.Mono;
 
 public interface ChatService {
-    Mono<ChatResponse> ask(ChatRequest request);
+    ChatResponse ask(String convId, String question);
 }

--- a/src/main/java/com/aivle/agriculture/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/service/ChatServiceImpl.java
@@ -1,31 +1,75 @@
 package com.aivle.agriculture.domain.chat.service;
 
-import com.aivle.agriculture.domain.chat.dto.ChatRequest;
+import com.aivle.agriculture.domain.Login.entity.User;
+import com.aivle.agriculture.domain.Login.repository.UserRepository;
 import com.aivle.agriculture.domain.chat.dto.ChatResponse;
-import com.aivle.agriculture.domain.common.client.FastApiClient;
+import com.aivle.agriculture.domain.chat.dto.RagPayload;
+import com.aivle.agriculture.domain.chat.entity.ChatMessage;
+import com.aivle.agriculture.domain.chat.entity.Role;
+import com.aivle.agriculture.domain.chat.repository.ChatMessageRepository;
 import com.aivle.agriculture.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import reactor.core.publisher.Mono;
 
-import static com.aivle.agriculture.global.response.ErrorCode.INTERNAL_SERVER_ERROR;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.aivle.agriculture.global.response.ErrorCode.NOT_FOUND;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
 
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
     private final FastApiClient fastApiClient;
 
     @Override
-    public Mono<ChatResponse> ask(ChatRequest request) {
-        return fastApiClient.askRag(request.question())
-                .onErrorMap(error -> {
-//                    if (error instanceof SomeSpecificException) {
-//                        return new CustomException(ErrorCode.INVALID_INPUT);
-//                    }
-                    return new CustomException(INTERNAL_SERVER_ERROR, error);
-                });
+    public ChatResponse ask(String convId, String question) {
+
+        String userEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(NOT_FOUND, "유저를 찾을 수 없습니다."));
+
+        ChatMessage userMessage = ChatMessage.builder()
+                .conversationId(convId)
+                .role(Role.USER)
+                .content(question)
+                .user(user)
+                .build();
+
+        chatMessageRepository.save(userMessage);
+
+        List<ChatMessage> history = chatMessageRepository.findRecentMessages(convId, PageRequest.of(0, 7));
+
+        Collections.reverse(history);
+
+        String context = history.stream()
+                .map(msg -> msg.getRole() + ": " + msg.getContent())
+                .collect(Collectors.joining("\n"));
+
+        RagPayload payload = RagPayload.builder()
+                .conversationId(convId)
+                .context(context)
+                .question(question)
+                .build();
+
+        ChatResponse chatResponse = fastApiClient.askRag(payload);
+
+        ChatMessage botMsg = ChatMessage.builder()
+                .conversationId(convId)
+                .role(Role.ASSISTANT)
+                .content(chatResponse.answer())
+                .user(user)
+                .build();
+
+        chatMessageRepository.save(botMsg);
+
+        return chatResponse;
     }
 }

--- a/src/main/java/com/aivle/agriculture/domain/chat/service/FastApiClient.java
+++ b/src/main/java/com/aivle/agriculture/domain/chat/service/FastApiClient.java
@@ -1,13 +1,10 @@
-package com.aivle.agriculture.domain.common.client;
+package com.aivle.agriculture.domain.chat.service;
 
 import com.aivle.agriculture.domain.chat.dto.ChatResponse;
-import org.springframework.beans.factory.annotation.Value;
+import com.aivle.agriculture.domain.chat.dto.RagPayload;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-import java.util.Map;
 
 @Component
 public class FastApiClient {
@@ -17,13 +14,14 @@ public class FastApiClient {
         this.webClient = webClient;
     }
 
-    public Mono<ChatResponse> askRag(String question) {
+    public ChatResponse askRag(RagPayload ragPayload) {
         return webClient.post()
                 .uri("/chat")
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(Map.of("question", question))
+                .bodyValue(ragPayload)
                 .retrieve()
-                .bodyToMono(ChatResponse.class);
+                .bodyToMono(ChatResponse.class)
+                .block();
     }
 }
 


### PR DESCRIPTION
### 📋 작업 내용
- 챗봇 백엔드(Spring) 및 FastAPI RAG 서버의 대화 이력 기반 구조로 고도화
- Spring: 대화 이력 DB 저장 및 최근 N턴 context 생성, FastAPI로 전달 로직 추가
- FastAPI: context(대화 이력) + question을 함께 받아 대화 흐름 반영
-  기존 단순 Q&A → 대화형 챗봇으로 전환

### 🌠 작업 결과
- Spring 백엔드에서 conversationId, context, question을 FastAPI로 전송
- FastAPI에서 context(이전 대화)와 question(이번 질문) 모두 활용하여 답변 생성
- 여러 턴의 대화 맥락이 잘 반영된 자연스러운 응답 확인

### ‼ 이슈 사항
- JPA(동기)와 WebFlux(비동기) 혼합 시 thread starvation 경고가 발생
  → 현재는 동기 방식(Spring MVC)으로 전체 구조 리팩토링하여 해결

Closes #13 